### PR TITLE
Update android splashScreen to 'cover' mode

### DIFF
--- a/app.json
+++ b/app.json
@@ -33,7 +33,7 @@
       "versionCode": 6,
       "splash": {
         "image": "./assets/images/splash-icon-android.png",
-        "resizeMode": "contain",
+        "resizeMode": "cover",
         "backgroundColor": "#0CAADC"
       }
     }


### PR DESCRIPTION
Simple solution for handling wrong android splash screen size. Must be enough for now. 